### PR TITLE
:godmode: [feat] (app/js/components/tree.js) added click listener for tree nodes

### DIFF
--- a/app/js/components/tree.js
+++ b/app/js/components/tree.js
@@ -8,14 +8,18 @@ var React = require('react');
 var d3 = require('d3');
 
 var D3Tree = React.createClass({
+  onClick: function(element) {
+    console.log('some element with onClick was clicked: ', element);
+  },
+
   componentDidMount: function() {
     var mountNode = this.getDOMNode();
 
-    makeTree(this.props.treeData, mountNode);
+    makeTree(this.props.treeData, mountNode, this.onClick);
   },
 
   shouldComponentUpdate: function(nextProps, nextState) {
-    makeTree(this.props.treeData, this.getDOMNode());
+    makeTree(this.props.treeData, this.getDOMNode(), this.onClick);
 
     return false; // Don't allow react to render component on prop change
   },
@@ -28,7 +32,7 @@ var D3Tree = React.createClass({
 });
 
   // D3 code that actually makes the tree
-  function makeTree(data, svgDomNode) {
+  function makeTree(data, svgDomNode, clickCallBack) {
     var treeData = data[0];
     // Calculate total nodes, max label length
     var totalNodes = 0;
@@ -173,6 +177,7 @@ var D3Tree = React.createClass({
         // d = toggleChildren(d);
         // update(d);
         centerNode(d);
+        clickCallBack(d);
     }
 
     function update(source) {

--- a/package.json
+++ b/package.json
@@ -19,14 +19,13 @@
   "dependencies": {
     "bcrypt": "^0.8.4",
     "bluebird": "^2.9.34",
+    "classnames": "^2.1.3",
+    "d3": "^3.5.6",
     "events": "^1.0.2",
     "express": "^4.13.3",
     "express-session": "^1.11.3",
-    "fs": "0.0.2",
-    "classnames": "^2.1.3",
-    "events": "^1.0.2",
-    "express": "^4.13.3",
     "flux": "^2.0.3",
+    "fs": "0.0.2",
     "keymirror": "~0.1.1",
     "lodash": "^3.10.1",
     "markdown": "^0.5.0",
@@ -36,11 +35,9 @@
     "react-router": "^0.13.3",
     "react-soundplayer": "^0.2.0",
     "sequelize": "^3.5.1",
+    "serve-favicon": "~2.3.0",
     "sqlite3": "^3.0.10",
-    "whatwg-fetch": "^0.9.0",
-    "sequelize": "^3.5.1",
-    "sqlite3": "^3.0.10",
-    "serve-favicon": "~2.3.0"
+    "whatwg-fetch": "^0.9.0"
   },
   "devDependencies": {
     "babelify": "^6.1.3",


### PR DESCRIPTION
For now it just console.log()s the node object (including d3 info from the tree).
Any properties given to the makeTree function in the json will be passed on and held in the nodes so you could for instance retrieve "song_id" if such a property existed and was passed to makeTree.
