### PR TITLE
:suspect: refactor (makeTree.js, tree.js) center nodes properly

### DIFF
--- a/app/js/components/makeTree.js
+++ b/app/js/components/makeTree.js
@@ -22,7 +22,9 @@ var exports = {};
     var nodeCircleRadius = 15; // 4.5 was original size
 
     // size of the diagram
-    var viewerWidth = $(document).width() - 250;
+    var widthOffset = $(document).width() - 900; // 900 is size of .treeBox element
+
+    var viewerWidth = $(document).width() - widthOffset;
     var viewerHeight = $(document).height() - 200;
 
     var tree = d3.layout.tree()

--- a/app/js/components/tree.js
+++ b/app/js/components/tree.js
@@ -30,7 +30,7 @@ class D3Tree extends React.Component {
 
   onClick(element) {
     console.log('some element with onClick was clicked: ', element);
-    // this.setState({ currentsong: element.id });
+    this.setState({ currentsong: element });
   }
 
   // componentDidMount() {
@@ -56,7 +56,7 @@ class D3Tree extends React.Component {
     return (
       <div className="treeDiv">
         <div className= "playerBox">
-          <AudioPlayer song = {song} mode = "home" />
+          <AudioPlayer song = {this.state.currentSong} mode = "home" />
         </div>
         <div className = "treeBox">
           <svg ref="songTree"></svg>


### PR DESCRIPTION
The D3 tree should center nodes in the middle of the class .treeBox element (currently 900 px wide)
