### PR TITLE
:bug:fix(songActionCreators.js,tree.js): fix SongAction getSongTree s…

### DIFF
--- a/app/js/actions/songActionCreators.js
+++ b/app/js/actions/songActionCreators.js
@@ -106,10 +106,21 @@ export default {
   getSongTree(song) {
     Utils.getTree('/tree', song)
     .then((json) => {
+      // Otherwise it just returns an array that the allSongStore can't use
+      let retObj = {
+        songs: json,
+        number: json.length
+      };
+      // assemble the tree object from the unsorted array
       let assembledTree = treeify(json);
       Dispatcher.dispatch({
         type: ActionType.RECEIVE_SONG_TREE,
         songTree: assembledTree
+      })
+      // Populate the allSongStore with the songs in the tree
+      Dispatcher.dispatch({
+        type: ActionType.RECEIVE_ALL_SONGS_SORTED,
+        songs: retObj
       })
     })
     .catch((err) => {

--- a/app/js/components/tree.js
+++ b/app/js/components/tree.js
@@ -101,7 +101,6 @@ class D3Tree extends React.Component {
     ModalStore.addActionListener(this._onAction);
     var userId = UserProfileStore.getCookieID();
     SongActions.getUserVotes(userId);
-    SongActions.getAllSongsSorted('like', 1);
   }
 
   componentWillUnmount() {
@@ -215,10 +214,8 @@ class D3Tree extends React.Component {
   _onChange() {
     AllSongStore.getSongById(this.state.currentSong.uuid)
     .then((song) => {
-      console.log('tree.js songs changed: ', song);
       this.setState({currentSong: song});
     });
-    // console.log('songs changed: ', this.state.currentSong);
   }
 
   _onAction() {


### PR DESCRIPTION
…o allSongStore is updated correctly and votes work

So, the tree didn't really work last time when I closed issue #190. It worked because there was only a page full of songs used for testing. This would obviously break if the tree got bigger (some songs would not be in the allSongStore and so voting would fail on them).
It should correctly load all songs in the tree into the allSongStore now so that the voting system will work.
